### PR TITLE
Fixes unable to update area

### DIFF
--- a/src/com/hetag/areareloader/AreaMethods.java
+++ b/src/com/hetag/areareloader/AreaMethods.java
@@ -147,7 +147,13 @@ public class AreaMethods {
 	}
 
 	public static boolean createNewArea(Player player, String area, int size) throws WorldEditException {
-		File dir = new File(AreaReloader.plugin.getDataFolder() + File.separator + "Areas" + File.separator + area);
+            if(AreaReloader.isDeleted.contains(area)){
+                AreaReloader.isDeleted.remove(area);
+                if(AreaReloader.debug){
+                    player.sendMessage(debugPrefix()+"Updating selected area.");
+                }
+            }
+            File dir = new File(AreaReloader.plugin.getDataFolder() + File.separator + "Areas" + File.separator + area);
 		if (dir.exists()) {
 			File[] files = dir.listFiles();
 			if ((files != null) && (files.length != 0)) {


### PR DESCRIPTION
Once you deleted some area the name it was using became "stuck" for
loading other areas, you could not load other areas with that name, only
after you restarted the server

This is an attempt to fix this issue.

**How to reproduce the issue**

Create some area
Remove the area

Create the area again
Attempt to load it


**Why**
Well, it is useful to update areas
